### PR TITLE
feat: Port the headers escaping feature

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -17,16 +17,6 @@
         <jmh.version>1.33</jmh.version>
     </properties>
 
-    <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
-            </extension>
-        </extensions>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>io.netty.contrib</groupId>
@@ -44,4 +34,31 @@
             <version>${jmh.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <testSourceDirectory>${project.build.sourceDirectory}</testSourceDirectory>
+                    <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
+                    <excludes>
+                        <exclude>**/*$*.class</exclude>
+                        <exclude>**/generated/*.class</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <perfReportDir>${project.build.directory}/reports/performance/</perfReportDir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/stomp/ExampleHeadersStompFrame.java
+++ b/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/stomp/ExampleHeadersStompFrame.java
@@ -57,8 +57,8 @@ public final class ExampleHeadersStompFrame {
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("timestamp", System.currentTimeMillis())
-                .set("Message-Type: 007");
+                .setLong("_:timestamp:_", System.currentTimeMillis())
+                .set("Message-Type: 007_:\\\r\n:_");
         EXAMPLES.put(HeadersType.SEVEN, headersSubframe);
 
         headersSubframe = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
@@ -68,10 +68,10 @@ public final class ExampleHeadersStompFrame {
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("timestamp", System.currentTimeMillis())
+                .setLong("_:timestamp:_", System.currentTimeMillis())
                 .set("Message-Type: 0011")
                 .set("Strict-Transport-Security", "max-age=31536000; includeSubdomains; preload")
-                .set("Server", "GitHub.com")
+                .set("\\Server\\", "\\GitHub.com\\")
                 .set("Expires", "Sat, 01 Jan 2000 00:00:00 GMT")
                 .set("Content-Language", "en");
         EXAMPLES.put(HeadersType.ELEVEN, headersSubframe);
@@ -83,17 +83,17 @@ public final class ExampleHeadersStompFrame {
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("timestamp", System.currentTimeMillis())
+                .setLong("_:timestamp:_", System.currentTimeMillis())
                 .set("Message-Type: 0020")
                 .set("date", "Wed, 22 Apr 2015 00:40:28 GMT")
                 .set("expires", "Tue, 31 Mar 1981 05:00:00 GMT")
                 .set("last-modified", "Wed, 22 Apr 2015 00:40:28 GMT")
                 .set("ms", "ms")
-                .set("pragma", "no-cache")
-                .set("server", "tsa_b")
-                .set("set-cookie", "noneofyourbusiness")
+                .set("\\\\pragma\\\\", "no-cache")
+                .set("\\Server\\", "\\GitHub.com\\")
+                .set("set-cookie", "\nnoneofyourbusiness\n")
                 .set("strict-transport-security", "max-age=631138519")
-                .set("version", "STOMP_v1.2")
+                .set("\rversion\r", "STOMP_v1.2")
                 .set("x-connection-hash", "e176fe40accc1e2c613a34bc1941aa98")
                 .set("x-content-type-options", "nosniff")
                 .set("x-frame-options", "SAMEORIGIN")

--- a/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompTestConstants.java
@@ -79,5 +79,22 @@ public final class StompTestConstants {
              '\n' +
              "body\1";
 
+    public static final String ESCAPED_MESSAGE_FRAME = "MESSAGE\n" +
+             "message-id:100\n" +
+             "subscription:1\n" +
+             "destination:/queue/a\\c\n" +
+             "header\\\\\\r\\n\\cName:header\\\\\\r\\n\\cValue\n" +
+             "header_\\\\_\\r_\\n_\\c_Name:header_\\\\_\\r_\\n_\\c_Value\n" +
+             "headerName\\c:\\cheaderValue\n" +
+             "\n\0";
+
+    public static final String INVALID_ESCAPED_MESSAGE_FRAME = "MESSAGE\n" +
+             "message-id:100\n" +
+             "subscription:0\n" +
+             "destination:/queue/a\n" +
+             "custom_colon\\c_header_\\ckey:custom_colon\\c_header_\\cvalue\n" +
+             "custom_invalid\\t_header_\\tkey:custom_invalid\\t_header_\\tvalue\n" +
+             "\n\0";
+
     private StompTestConstants() { }
 }


### PR DESCRIPTION
Motivation:
Porting the headers escaping feature, see https://github.com/netty/netty/pull/12585.

Modifications:
Add escaping to stomp encoder/decoder according specification.

Result:
Stomp codec comply with STOMP 1.2 and in most case backward compatible with 1.1 and 1.0.