### PR TITLE
chore: Code polishing

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -14,7 +14,7 @@
     <version>${parent.version}</version>
 
     <properties>
-        <jmh.version>1.33</jmh.version>
+        <jmh.version>1.35</jmh.version>
     </properties>
 
     <dependencies>
@@ -27,6 +27,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty5-microbench</artifactId>
             <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/stomp/ExampleHeadersStompFrame.java
+++ b/benchmarks/src/main/java/io/netty/contrib/microbenchmarks/stomp/ExampleHeadersStompFrame.java
@@ -38,67 +38,67 @@ public final class ExampleHeadersStompFrame {
     public static final Map<HeadersType, HeadersStompFrame> EXAMPLES = new EnumMap<>(HeadersType.class);
 
     static {
-        HeadersStompFrame headersSubframe = new DefaultHeadersStompFrame(StompCommand.RECEIPT);
-        headersSubframe.headers()
+        HeadersStompFrame headersFrame = new DefaultHeadersStompFrame(StompCommand.RECEIPT);
+        headersFrame.headers()
                 .set(StompHeaders.RECEIPT_ID, UUID.randomUUID().toString());
-        EXAMPLES.put(HeadersType.ONE, headersSubframe);
+        EXAMPLES.put(HeadersType.ONE, headersFrame);
 
-        headersSubframe = new DefaultHeadersStompFrame(StompCommand.ERROR);
-        headersSubframe.headers()
+        headersFrame = new DefaultHeadersStompFrame(StompCommand.ERROR);
+        headersFrame.headers()
                 .set(StompHeaders.RECEIPT_ID, UUID.randomUUID().toString())
                 .set(StompHeaders.CONTENT_TYPE, "text/plain")
                 .set(StompHeaders.MESSAGE, "malformed frame received");
-        EXAMPLES.put(HeadersType.THREE, headersSubframe);
+        EXAMPLES.put(HeadersType.THREE, headersFrame);
 
-        headersSubframe = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
-        headersSubframe.headers()
+        headersFrame = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
+        headersFrame.headers()
                 .set(StompHeaders.SUBSCRIPTION, "7")
                 .set(StompHeaders.MESSAGE_ID, UUID.randomUUID().toString())
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("_:timestamp:_", System.currentTimeMillis())
-                .set("Message-Type: 007_:\\\r\n:_");
-        EXAMPLES.put(HeadersType.SEVEN, headersSubframe);
+                .setLong("timestamp", System.currentTimeMillis())
+                .set("Message-Type: 007");
+        EXAMPLES.put(HeadersType.SEVEN, headersFrame);
 
-        headersSubframe = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
-        headersSubframe.headers()
+        headersFrame = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
+        headersFrame.headers()
                 .set(StompHeaders.SUBSCRIPTION, "11")
                 .set(StompHeaders.MESSAGE_ID, UUID.randomUUID().toString())
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("_:timestamp:_", System.currentTimeMillis())
+                .setLong("timestamp", System.currentTimeMillis())
                 .set("Message-Type: 0011")
                 .set("Strict-Transport-Security", "max-age=31536000; includeSubdomains; preload")
-                .set("\\Server\\", "\\GitHub.com\\")
+                .set("Server", "GitHub.com")
                 .set("Expires", "Sat, 01 Jan 2000 00:00:00 GMT")
                 .set("Content-Language", "en");
-        EXAMPLES.put(HeadersType.ELEVEN, headersSubframe);
+        EXAMPLES.put(HeadersType.ELEVEN, headersFrame);
 
-        headersSubframe = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
-        headersSubframe.headers()
+        headersFrame = new DefaultHeadersStompFrame(StompCommand.MESSAGE);
+        headersFrame.headers()
                 .set(StompHeaders.SUBSCRIPTION, "20")
                 .set(StompHeaders.MESSAGE_ID, UUID.randomUUID().toString())
                 .set(StompHeaders.DESTINATION, "/queue/chat")
                 .set(StompHeaders.CONTENT_TYPE, "application/octet-stream")
                 .set(StompHeaders.ACK, UUID.randomUUID().toString())
-                .setLong("_:timestamp:_", System.currentTimeMillis())
+                .setLong("timestamp", System.currentTimeMillis())
                 .set("Message-Type: 0020")
                 .set("date", "Wed, 22 Apr 2015 00:40:28 GMT")
                 .set("expires", "Tue, 31 Mar 1981 05:00:00 GMT")
                 .set("last-modified", "Wed, 22 Apr 2015 00:40:28 GMT")
                 .set("ms", "ms")
-                .set("\\\\pragma\\\\", "no-cache")
-                .set("\\Server\\", "\\GitHub.com\\")
-                .set("set-cookie", "\nnoneofyourbusiness\n")
+                .set("pragma", "no-cache")
+                .set("server", "tsa_b")
+                .set("set-cookie", "noneofyourbusiness")
                 .set("strict-transport-security", "max-age=631138519")
-                .set("\rversion\r", "STOMP_v1.2")
+                .set("version", "STOMP_v1.2")
                 .set("x-connection-hash", "e176fe40accc1e2c613a34bc1941aa98")
                 .set("x-content-type-options", "nosniff")
                 .set("x-frame-options", "SAMEORIGIN")
                 .set("x-transaction", "a54142ede693444d9");
-        EXAMPLES.put(HeadersType.TWENTY, headersSubframe);
+        EXAMPLES.put(HeadersType.TWENTY, headersFrame);
     }
 
     private ExampleHeadersStompFrame() {

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/ContentStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/ContentStompFrame.java
@@ -20,7 +20,7 @@ import io.netty5.channel.ChannelPipeline;
 import io.netty5.util.Resource;
 
 /**
- * An STOMP chunk which is used for STOMP chunked transfer-encoding. {@link StompFrameDecoder} generates
+ * A STOMP chunk which is used for STOMP chunked transfer-encoding. {@link StompFrameDecoder} generates
  * {@link ContentStompFrame} after {@link HeadersStompFrame} when the content is large or the encoding of
  * the content is 'chunked.  If you prefer not to receive multiple {@link StompFrame}s for a single
  * {@link FullStompFrame}, place {@link StompFrameAggregator} after {@link StompFrameDecoder} in the

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/DefaultStompFrame.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Skeleton implementation of the {@link StompFrame}.
+ */
 public abstract class DefaultStompFrame implements StompFrame {
 
     private DecoderResult decoderResult = DecoderResult.success();

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/DefaultStompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/DefaultStompHeaders.java
@@ -26,6 +26,9 @@ import java.util.Map.Entry;
 import static io.netty5.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty5.util.AsciiString.CASE_SENSITIVE_HASHER;
 
+/**
+ * Default implementation of the {@link StompHeaders}.
+ */
 public class DefaultStompHeaders extends DefaultHeaders<CharSequence, CharSequence, StompHeaders> implements StompHeaders {
     public DefaultStompHeaders() {
         super(CASE_SENSITIVE_HASHER, CharSequenceValueConverter.INSTANCE);

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompCommand.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompCommand.java
@@ -19,21 +19,23 @@ package io.netty.contrib.handler.codec.stomp;
  * STOMP commands.
  */
 public enum StompCommand {
-
-    STOMP,
-    CONNECT,
-    CONNECTED,
+    // Client commands.
     SEND,
     SUBSCRIBE,
     UNSUBSCRIBE,
+    BEGIN,
+    COMMIT,
+    ABORT,
     ACK,
     NACK,
-    BEGIN,
-    ABORT,
-    COMMIT,
     DISCONNECT,
+    CONNECT,
+    STOMP,
+    // Server commands.
+    CONNECTED,
     MESSAGE,
     RECEIPT,
     ERROR,
+    // Non-protocol internal commands.
     UNKNOWN
 }

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameAggregator.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameAggregator.java
@@ -25,8 +25,9 @@ import io.netty5.handler.codec.MessageAggregator;
 /**
  * A {@link ChannelHandler} that aggregates an {@link HeadersStompFrame}
  * and its following {@link ContentStompFrame}s into a single {@link FullStompFrame}.
- * It is useful when you don't want to take care of STOMP frames whose content is 'chunked'.  Insert this
- * handler after {@link StompFrameDecoder} in the {@link ChannelPipeline}:
+ * <p>
+ * It is useful when you don't want to take care of STOMP frames whose content is 'chunked'.
+ * Insert this handler after {@link StompFrameDecoder} in the {@link ChannelPipeline}.
  */
 public class StompFrameAggregator<C extends ContentStompFrame<C>>
     extends MessageAggregator<StompFrame, HeadersStompFrame, ContentStompFrame<C>, FullStompFrame> {

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameDecoder.java
@@ -31,11 +31,11 @@ import java.util.Objects;
 /**
  * Decodes {@link Buffer}s into {@link HeadersStompFrame}s and {@link ContentStompFrame}s.
  *
- * <h3>Parameters to control memory consumption: </h3>
+ * <h3>Parameters to control memory consumption:</h3>
  * {@code maxLineLength} the maximum length of line - restricts length of command and header lines If the length of the
  * initial line exceeds this value, a {@link TooLongFrameException} will be raised.
- * <br>
- * {@code maxChunkSize} The maximum length of the content or each chunk.  If the content length (or the length of each
+ * <p>
+ * {@code maxChunkSize} The maximum length of the content or each chunk. If the content length (or the length of each
  * chunk) exceeds this value, the content or chunk ill be split into multiple {@link ContentStompFrame}s whose length
  * is {@code maxChunkSize} at maximum.
  *
@@ -221,7 +221,7 @@ public class StompFrameDecoder extends ByteToMessageDecoder {
 
             return command;
         } catch (IllegalArgumentException e) {
-            throw new DecoderException("Cannot to parse command: " + commandSequence);
+            throw new DecoderException("Cannot to parse command " + commandSequence);
         }
     }
 
@@ -242,8 +242,9 @@ public class StompFrameDecoder extends ByteToMessageDecoder {
     private static long getContentLength(StompHeaders headers) {
         long contentLength = headers.getLong(StompHeaders.CONTENT_LENGTH, 0L);
         if (contentLength < 0) {
-            throw new DecoderException(StompHeaders.CONTENT_LENGTH + " must be non-negative");
+            throw new DecoderException("The `content-length` header must be non-negative, was " + contentLength);
         }
+
         return contentLength;
     }
 
@@ -322,7 +323,7 @@ public class StompFrameDecoder extends ByteToMessageDecoder {
             }
 
             if (++lineLength > maxLineLength) {
-                throw new TooLongFrameException("An STOMP line is larger than " + maxLineLength + " bytes.");
+                throw new TooLongFrameException("STOMP line is larger than " + maxLineLength + " bytes");
             }
 
             // 1 byte   -   0xxxxxxx                    -  7 bits
@@ -383,18 +384,20 @@ public class StompFrameDecoder extends ByteToMessageDecoder {
                 if (value == null) {
                     return false;
                 }
+
                 if (name == null && value.length() == 0) {
                     return true;
                 }
+
                 if (valid) {
                     headersFrame.headers().add(name, value.toString());
                 } else if (validateHeaders) {
                     if (StringUtil.isNullOrEmpty(name)) {
-                        throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
+                        throw new IllegalArgumentException("Received an invalid header line '" + value + '\'');
                     }
+
                     String line = name + ':' + value;
-                    throw new IllegalArgumentException("a header value or name contains a prohibited character ':'"
-                            + ", " + line);
+                    throw new IllegalArgumentException("Header value or name contains prohibited character ':', " + line);
                 }
             }
         }

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompFrameEncoder.java
@@ -82,7 +82,7 @@ public class StompFrameEncoder extends MessageToMessageEncoder<StompFrame> {
             out.add(convertedFull);
         } else if (msg instanceof HeadersStompFrame) {
             HeadersStompFrame headersFrame = (HeadersStompFrame) msg;
-            Buffer buffer = ctx.bufferAllocator().allocate(headersSubFrameSize(headersFrame));
+            Buffer buffer = ctx.bufferAllocator().allocate(headersStompFrameSize(headersFrame));
             encodeHeaders(headersFrame, buffer);
 
             Object convertedHeaders = convertHeadersFrame(headersFrame, buffer);
@@ -108,7 +108,7 @@ public class StompFrameEncoder extends MessageToMessageEncoder<StompFrame> {
 
     /**
      * An extension method to convert a STOMP encoded buffer to a different message type
-     * based on an original {@link HeadersStompFrame} headers sub frame.
+     * based on an original {@link HeadersStompFrame} headers stomp frame.
      *
      * <p>By default an encoded buffer is returned as is.
      */
@@ -118,7 +118,7 @@ public class StompFrameEncoder extends MessageToMessageEncoder<StompFrame> {
 
     /**
      * An extension method to convert a STOMP encoded buffer to a different message type
-     * based on an original {@link HeadersStompFrame} content sub frame.
+     * based on an original {@link ContentStompFrame} content stomp frame.
      *
      * <p>By default an encoded buffer is returned as is.
      */
@@ -130,7 +130,7 @@ public class StompFrameEncoder extends MessageToMessageEncoder<StompFrame> {
      * Returns a heuristic size for headers (32 bytes per header line) + (2 bytes for colon and eol) + (additional
      * command buffer).
      */
-    protected int headersSubFrameSize(HeadersStompFrame headersFrame) {
+    protected int headersStompFrameSize(HeadersStompFrame headersFrame) {
         int estimatedSize = headersFrame.headers().size() * 34 + 48;
         if (estimatedSize < 128) {
             return 128;
@@ -142,7 +142,7 @@ public class StompFrameEncoder extends MessageToMessageEncoder<StompFrame> {
 
     private Buffer encodeFullFrame(FullStompFrame fullFrame, ChannelHandlerContext ctx) {
         int contentReadableBytes = fullFrame.payload().readableBytes();
-        Buffer buf = ctx.bufferAllocator().allocate(headersSubFrameSize(fullFrame) + contentReadableBytes);
+        Buffer buf = ctx.bufferAllocator().allocate(headersStompFrameSize(fullFrame) + contentReadableBytes);
         encodeHeaders(fullFrame, buf);
 
         if (contentReadableBytes > 0) {

--- a/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/contrib/handler/codec/stomp/StompHeaders.java
@@ -72,12 +72,12 @@ public interface StompHeaders extends Headers<CharSequence, CharSequence, StompH
     /**
      * Returns {@code true} if a header with the {@code name} and {@code value} exists, {@code false} otherwise.
      * <p>
-     * If {@code ignoreCase} is {@code true} then a case insensitive compare is done on the value.
+     * If {@code ignoreCase} is {@code true} then a case-insensitive compare is done on the value.
      *
      * @param name       the name of the header to find
      * @param value      the value of the header to find
-     * @param ignoreCase {@code true} then a case insensitive compare is run to compare values.
-     *                   otherwise a case sensitive compare is run to compare values.
+     * @param ignoreCase {@code true} then a case-insensitive compare is run to compare values.
+     *                   otherwise a case-sensitive compare is run to compare values.
      */
     boolean contains(CharSequence name, CharSequence value, boolean ignoreCase);
 

--- a/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompFrameAggregatorTest.java
+++ b/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompFrameAggregatorTest.java
@@ -158,7 +158,7 @@ class StompFrameAggregatorTest {
                     .isEqualTo(StompCommand.SEND);
 
             assertThat(fullFrame.decoderResult().isFailure()).isTrue();
-            assertThat(fullFrame.decoderResult().cause()).hasMessage("received an invalid header line ':header-value'");
+            assertThat(fullFrame.decoderResult().cause()).hasMessage("Received an invalid header line ':header-value'");
         }
     }
 

--- a/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompFrameDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/contrib/handler/codec/stomp/StompFrameDecoderTest.java
@@ -203,7 +203,7 @@ public class StompFrameDecoderTest {
 
         assertThat(headersFrame.decoderResult().isFailure()).isTrue();
         assertThat(headersFrame.decoderResult().cause()).hasMessage(
-                "a header value or name contains a prohibited character ':', current-time:2000-01-01T00:00:00");
+                "Header value or name contains prohibited character ':', current-time:2000-01-01T00:00:00");
     }
 
     @Test
@@ -220,7 +220,7 @@ public class StompFrameDecoderTest {
                 .isEqualTo(StompCommand.SEND);
 
         assertThat(headersFrame.decoderResult().isFailure()).isTrue();
-        assertThat(headersFrame.decoderResult().cause()).hasMessage("received an invalid header line ':header-value'");
+        assertThat(headersFrame.decoderResult().cause()).hasMessage("Received an invalid header line ':header-value'");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
                 <!-- Eclipse-related OSGi manifests


### PR DESCRIPTION
Motivation:
Code polishing after rename the STOMP frames.

Modifications:
Remove all `sub` prefixes, all exceptions start with a capital letter, fix javadocs.

Result:
Code is cleaner.